### PR TITLE
Can now be installed via NPM and used with Browserify

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ Please file any issues and bugs in our main repository at [angular-translate/ang
 $ bower install angular-translate-handler-log
 ```
 
+### via NPM
+
+```bash
+$ npm install angular-translate-handler-log
+```
+
 ### via cdnjs
 
 Please have a look at https://cdnjs.com/libraries/angular-translate-handler-log for specific versions.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "angular-translate-handler-log",
+  "version": "2.7.0",
+  "description": "Uses angular's $log service to give a warning when trying to translate a translation id which doesn't exist.",
+  "main": "angular-translate-handler-log.js",
+  "repository": {
+    "type": "git",
+    "url": "https://mchambaud@github.com/mchambaud/bower-angular-translate-handler-log.git"
+  },
+  "keywords": [
+    "angular",
+    "angular-translate",
+    "angular-translate-handler-log"
+  ],
+  "author": "Pascal Precht",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/mchambaud/bower-angular-translate-handler-log/issues"
+  },
+  "homepage": "https://github.com/mchambaud/bower-angular-translate-handler-log"
+}


### PR DESCRIPTION
Added PACKAGE.JSON to allow installing angular-translate-handler-log using NPM, enabling proper Browserification in the process.
